### PR TITLE
docs: define application database architecture

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,6 +32,8 @@ None
 ## Checklist
 
 - [ ] This PR targets `dev`.
+- [ ] Applied the required label and GitHub Project fields.
+- [ ] Applied the relevant milestone, when one applies.
 - [ ] Confirmed the change is focused and the diff was reviewed.
 - [ ] Validated all relevant documentation and feature specifications are updated, when applicable.
 - [ ] Ran relevant checks, or explained why they could not be run.

--- a/docs/core-statements.md
+++ b/docs/core-statements.md
@@ -123,7 +123,10 @@ when its additional context is needed.
 - The Server stores its application state, including users, sessions, policy,
   secrets, Service Connections, and operational state, in its
   **[Application Database](glossary.md#applications-and-interfaces)**. The
-  Application Database is separate from every Log Module destination.
+  Application Database is separate from every Log Module destination. The two
+  never share application logic, crates, files, schemas, connections,
+  configuration, resources, lifecycle, or backup and retention behavior, even
+  when both use the same technology.
 - The Server isolates Application Database persistence behind an internal
   backend contract. Each supported Application Database backend is a dedicated
   Rust crate that owns its database-driver integration, schema migrations,
@@ -132,14 +135,15 @@ when its additional context is needed.
   lifecycle behavior.
 - The MVP Application Database uses the SQLite backend crate.
 - The MVP default Log Module uses SQLite and stores System Logs and Audit Logs
-  in a database separate from the Application Database.
+  in a database separate from the Application Database. Selecting SQLite for
+  both creates separate implementations and resources.
 - **[Init](glossary.md#states-and-requests)** selects and configures the
-  Application Database and selects, configures, and activates one or more
-  initial Log Modules. Init assigns configured Log Modules separately to
-  System Logs and Audit Logs; the same Log Module may receive both types. Init
-  does not complete, and the Server does not begin normal operation, until both
-  assignments are valid and the Audit Log assignment can durably record Audit
-  Logs.
+  Application Database in a host-local bootstrap step, then separately selects,
+  configures, and activates one or more initial Log Modules. Init assigns
+  configured Log Modules separately to System Logs and Audit Logs; the same Log
+  Module may receive both types. Init does not complete, and the Server does
+  not begin normal operation, until both assignments are valid and the Audit
+  Log assignment can durably record Audit Logs.
 - The Application Database is not a module and cannot be enabled, disabled, or
   changed after Init. Weavelit does not support in-place migration between
   Application Database technologies. Application Database backends are

--- a/docs/core-statements.md
+++ b/docs/core-statements.md
@@ -133,8 +133,9 @@ when its additional context is needed.
   backend contract. Each supported Application Database backend is a dedicated
   Rust crate that owns its database-driver integration, schema migrations,
   transaction behavior, connection health handling, and backend-specific
-  errors. The Server core owns backend selection, configuration validation, and
-  lifecycle behavior.
+  errors, including validation of its connection and storage settings. The
+  Server core owns backend selection, common bootstrap-configuration validation,
+  and lifecycle behavior.
 - The MVP Application Database uses the SQLite backend crate.
 - The MVP default Log Module uses SQLite and stores System Logs and Audit Logs
   in a database separate from the Application Database. Selecting SQLite for

--- a/docs/core-statements.md
+++ b/docs/core-statements.md
@@ -124,9 +124,11 @@ when its additional context is needed.
   secrets, Service Connections, and operational state, in its
   **[Application Database](glossary.md#applications-and-interfaces)**. The
   Application Database is separate from every Log Module destination. The two
-  never share application logic, crates, files, schemas, connections,
-  configuration, resources, lifecycle, or backup and retention behavior, even
-  when both use the same technology.
+  never share Weavelit-owned persistence logic or implementation crates, files,
+  schemas, connections, configuration, resources, lifecycle, or backup and
+  retention behavior, even when both use the same technology. They may use the
+  same workspace-pinned third-party dependency, such as `rusqlite`, without
+  sharing persistence behavior.
 - The Server isolates Application Database persistence behind an internal
   backend contract. Each supported Application Database backend is a dedicated
   Rust crate that owns its database-driver integration, schema migrations,

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -17,7 +17,8 @@ Connections, and operational state. It is selected and configured during
 **[Log Module](#applications-and-interfaces)** destination, and is not a
 module. Application Database persistence uses an internal backend contract;
 each supported backend is a dedicated Rust crate. The Server core owns backend
-selection, configuration validation, and lifecycle behavior. Backends are
+selection, common bootstrap-configuration validation, and lifecycle behavior.
+Each backend validates its own connection and storage settings. Backends are
 compiled into the Server package and are not runtime-installable plugins. The
 MVP backend is SQLite. Application Database state and a Log Module destination
 never share Weavelit-owned persistence logic or implementation crates, files,

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -19,7 +19,9 @@ module. Application Database persistence uses an internal backend contract;
 each supported backend is a dedicated Rust crate. The Server core owns backend
 selection, configuration validation, and lifecycle behavior. Backends are
 compiled into the Server package and are not runtime-installable plugins. The
-MVP backend is SQLite.
+MVP backend is SQLite. Application Database state and a Log Module destination
+never share application logic, crates, files, schemas, connections,
+configuration, resources, lifecycle, or backup and retention behavior.
 
 **Log Module** - A reusable server-side Rust library that receives pre-redacted structured **[System Logs](#applications-and-interfaces)**, **[Audit Logs](#applications-and-interfaces)**, or both and persists or delivers them to a configured destination. Log Modules are available to **[Administrators](#identities-and-access)**, disabled by default except for the module selected during **[Init](#states-and-requests)**, and configured only through server-administration functions.
 
@@ -100,7 +102,7 @@ from a shared secret and the current time by an authenticator application.
 
 ## States and Requests
 
-**Init** - The first-time process and state in which a **[Host Administrator](#identities-and-access)** creates the **[Administrators Group](#identities-and-access)**, creates the first local **[Human User](#identities-and-access)**, adds that user to the Administrators Group, selects and configures the **[Application Database](#applications-and-interfaces)**, selects, configures, and activates one or more initial Log Modules, and assigns configured Log Modules separately to System Logs and Audit Logs. The same Log Module may receive both log types. Init must validate both assignments, including durable Audit Log recording, before the Server starts normal operation.
+**Init** - The first-time process and state in which a **[Host Administrator](#identities-and-access)** creates the **[Administrators Group](#identities-and-access)**, creates the first local **[Human User](#identities-and-access)**, adds that user to the Administrators Group, selects and configures the **[Application Database](#applications-and-interfaces)** in a host-local bootstrap step, then separately selects, configures, and activates one or more initial Log Modules and assigns configured Log Modules to System Logs and Audit Logs. The same Log Module may receive both log types, but it does not reuse Application Database resources. Init must validate both assignments, including durable Audit Log recording, before the Server starts normal operation.
 
 **Operational Request** - A typed request for a supported **[Operation](#applications-and-interfaces)** accepted through a **[Client Module](#applications-and-interfaces)** and processed by the **[Weavelit Server](#applications-and-interfaces)**.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -20,8 +20,10 @@ each supported backend is a dedicated Rust crate. The Server core owns backend
 selection, configuration validation, and lifecycle behavior. Backends are
 compiled into the Server package and are not runtime-installable plugins. The
 MVP backend is SQLite. Application Database state and a Log Module destination
-never share application logic, crates, files, schemas, connections,
-configuration, resources, lifecycle, or backup and retention behavior.
+never share Weavelit-owned persistence logic or implementation crates, files,
+schemas, connections, configuration, resources, lifecycle, or backup and
+retention behavior. They may use the same workspace-pinned third-party
+dependency, such as `rusqlite`, without sharing persistence behavior.
 
 **Log Module** - A reusable server-side Rust library that receives pre-redacted structured **[System Logs](#applications-and-interfaces)**, **[Audit Logs](#applications-and-interfaces)**, or both and persists or delivers them to a configured destination. Log Modules are available to **[Administrators](#identities-and-access)**, disabled by default except for the module selected during **[Init](#states-and-requests)**, and configured only through server-administration functions.
 

--- a/docs/log-modules/log-module-design.md
+++ b/docs/log-modules/log-module-design.md
@@ -14,11 +14,13 @@ for the two log types.
 
 Application Database bootstrap configuration is selected and configured in a
 separate preceding Init step. Selecting the same underlying technology for an
-Application Database and a Log Module does not reuse its crate, code,
-configuration, database file, schema, connection, or other resources. A Log
-Module may instead deliver records to a non-database destination, such as email,
-an API endpoint, or Checkmk; its destination type does not affect Application
-Database behavior.
+Application Database and a Log Module does not reuse Weavelit-owned persistence
+logic or implementation crates, configuration, database file, schema,
+connection, or other resources. They may use the same workspace-pinned
+third-party dependency, such as `rusqlite`, without sharing persistence
+behavior. A Log Module may instead deliver records to a non-database destination,
+such as email, an API endpoint, or Checkmk; its destination type does not affect
+Application Database behavior.
 
 Interactive Init collects configuration in this order:
 

--- a/docs/log-modules/log-module-design.md
+++ b/docs/log-modules/log-module-design.md
@@ -12,6 +12,14 @@ During **[Init](../glossary.md#states-and-requests)**, the
 configures, and activates one or more Log Modules before assigning destinations
 for the two log types.
 
+Application Database bootstrap configuration is selected and configured in a
+separate preceding Init step. Selecting the same underlying technology for an
+Application Database and a Log Module does not reuse its crate, code,
+configuration, database file, schema, connection, or other resources. A Log
+Module may instead deliver records to a non-database destination, such as email,
+an API endpoint, or Checkmk; its destination type does not affect Application
+Database behavior.
+
 Interactive Init collects configuration in this order:
 
 1. Select and configure a Log Module for **[System Logs](../glossary.md#applications-and-interfaces)**.
@@ -36,3 +44,4 @@ persisted.
 - [Security Model](../security-model.md)
 - [Open Questions](../open-questions.md)
 - [Glossary](../glossary.md)
+- [Application Database Design](../server/database/application-database-design.md)

--- a/docs/plan/AGENTS.md
+++ b/docs/plan/AGENTS.md
@@ -29,7 +29,8 @@ Follow this section for workflow, sequencing, and decision order when making cha
 - Before editing, read the nearest `AGENTS.md`, then `../AGENTS.md`, and the repository-root `AGENTS.md`.
 - Read `issues/issues.md` before changing how open work is summarized or mapped to GitHub Project metadata.
 - Read the affected document in `milestones/` before changing its outcomes. Keep milestones aligned with canonical documents for settled product, security, and technical decisions; unresolved choices remain in [Open Questions](../open-questions.md).
-- Read `project/AGENTS.md` and `project/issue-standards.md` before changing documented GitHub issue metadata or Project workflow values.
+- Read `project/AGENTS.md` and `project/project-standards.md` before changing
+  documented GitHub Issue or Pull Request metadata or Project workflow values.
 - Keep planning outcomes aligned with canonical documents for settled product, security, and technical decisions instead of redefining those decisions.
 - Place milestone-specific guidance and outcome documents in `milestones/`.
 

--- a/docs/plan/issues/AGENTS.md
+++ b/docs/plan/issues/AGENTS.md
@@ -29,7 +29,9 @@ Follow this section for workflow, sequencing, and decision order when making cha
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, `../../AGENTS.md`, and the repository-root `AGENTS.md`.
 - Read `templates/AGENTS.md` before changing an agent-created issue body template.
 - Create an issue by copying the matching template in `templates/` beginning with `##` into a temporary body file, replacing every bracketed placeholder, and passing it to `gh issue create --body-file`.
-- Set the native issue type with `gh issue create --type`; then assign the component label, `Priority`, GitHub Milestone, Project status, and applicable issue relationships defined in `../project/issue-standards.md`.
+- Set the native issue type with `gh issue create --type`; then assign the
+  component label, `Priority`, GitHub Milestone, Project status, and applicable
+  issue relationships defined in `../project/project-standards.md`.
 - Refresh issue records from the repository issue tracker, GitHub Milestones, and the Weavelit GitHub Project in the same update.
 - Include each open repository issue exactly once and summarize its stated outcome or decision without replacing its acceptance criteria.
 - Treat demonstration entries as documentation examples only; do not create a GitHub issue without explicit approval.

--- a/docs/plan/issues/issues.md
+++ b/docs/plan/issues/issues.md
@@ -21,7 +21,7 @@
 > assign the applicable repository component labels, `Priority` value, GitHub
 > Milestone, Project status, and issue relationships. Do not recreate retired
 > Project fields for type, area, delivery priority, size, or estimate. See the
-> [GitHub Project and Issue Standards](../project/issue-standards.md).
+> [GitHub Project Standards](../project/project-standards.md).
 
 ## Standard Record Format
 
@@ -147,7 +147,7 @@ routine metadata update to the affected issue's record.
 - [Decision Template](templates/decision-template.md)
 - [Epic Template](templates/epic-template.md)
 - [Feature Template](templates/feature-template.md)
-- [GitHub Project and Issue Standards](../project/issue-standards.md)
+- [GitHub Project Standards](../project/project-standards.md)
 - [Milestone 1 Outcomes](../milestones/milestone-1.md)
 - [Risk Template](templates/risk-template.md)
 - [Task Template](templates/task-template.md)

--- a/docs/plan/issues/templates/AGENTS.md
+++ b/docs/plan/issues/templates/AGENTS.md
@@ -10,7 +10,8 @@ structure without relying on GitHub Issue Forms.
 Use this section to understand what this directory owns, what it does not own, and where child paths own detailed rules.
 
 - This directory owns the Markdown body structure and native-type instructions for agent-created GitHub issues.
-- It does not own live issue metadata such as labels, `Priority`, milestones, Project status, or issue relationships; [GitHub Project and Issue Standards](../../project/issue-standards.md) owns the documented values and assignment workflow.
+- It does not own live issue metadata such as labels, `Priority`, milestones,
+  Project status, or issue relationships; [GitHub Project Standards](../../project/project-standards.md) owns the documented values and assignment workflow.
 - This guide applies to the template files in this directory; [Open Issue Overview](../issues.md) owns the snapshot of issues created from them.
 
 ## Asset Inventory
@@ -34,7 +35,8 @@ Follow this section for workflow, sequencing, and decision order when making cha
 - Copy only the sections beginning with `##` into the temporary body file passed to `gh issue create --body-file`.
 - Replace every bracketed placeholder before creating the issue.
 - Pass the template's `Native type` value to `gh issue create --type`.
-- Apply labels, `Priority`, milestones, Project status, and relationships according to [GitHub Project and Issue Standards](../../project/issue-standards.md).
+- Apply labels, `Priority`, milestones, Project status, and relationships
+  according to [GitHub Project Standards](../../project/project-standards.md).
 
 ## Standards and Conventions
 
@@ -44,7 +46,8 @@ Treat every rule in this section as mandatory for formatting, naming, scope boun
 - Keep the required heading order and keep this guide under 100 lines.
 - Name each file `<native-type>-template.md` using the lowercase native issue type shown in its hidden `Native type` instruction.
 - Keep each template's hidden creation instructions before the copied `##` body sections.
-- Keep the `## Related Documents` section at the end of each template and link it to `../../project/issue-standards.md`.
+- Keep the `## Related Documents` section at the end of each template and link
+  it to `../../project/project-standards.md`.
 - Do not place live issue assignments or Project values in a template body; apply them after issue creation through the documented GitHub workflow.
 - Documentation is AI-maintained: agents must keep it accurate, complete, logically structured, and located in the appropriate documentation boundary.
 - Every change must include an update to its relevant documentation under `docs/` in the same change.

--- a/docs/plan/issues/templates/bug-template.md
+++ b/docs/plan/issues/templates/bug-template.md
@@ -50,4 +50,4 @@ Environment and evidence:
 
 ## Related Documents
 
-- [GitHub Project and Issue Standards](../../project/issue-standards.md)
+- [GitHub Project Standards](../../project/project-standards.md)

--- a/docs/plan/issues/templates/decision-template.md
+++ b/docs/plan/issues/templates/decision-template.md
@@ -31,4 +31,4 @@ component labels, Priority, milestone, Project status, and parent epic.
 
 ## Related Documents
 
-- [GitHub Project and Issue Standards](../../project/issue-standards.md)
+- [GitHub Project Standards](../../project/project-standards.md)

--- a/docs/plan/issues/templates/epic-template.md
+++ b/docs/plan/issues/templates/epic-template.md
@@ -30,4 +30,4 @@ component labels, Priority, milestone, Project status, and child issues.
 
 ## Related Documents
 
-- [GitHub Project and Issue Standards](../../project/issue-standards.md)
+- [GitHub Project Standards](../../project/project-standards.md)

--- a/docs/plan/issues/templates/feature-template.md
+++ b/docs/plan/issues/templates/feature-template.md
@@ -38,4 +38,4 @@ component labels, Priority, milestone, Project status, and parent epic.
 
 ## Related Documents
 
-- [GitHub Project and Issue Standards](../../project/issue-standards.md)
+- [GitHub Project Standards](../../project/project-standards.md)

--- a/docs/plan/issues/templates/risk-template.md
+++ b/docs/plan/issues/templates/risk-template.md
@@ -38,4 +38,4 @@ component labels, Priority, milestone, Project status, and parent epic when appl
 
 ## Related Documents
 
-- [GitHub Project and Issue Standards](../../project/issue-standards.md)
+- [GitHub Project Standards](../../project/project-standards.md)

--- a/docs/plan/issues/templates/task-template.md
+++ b/docs/plan/issues/templates/task-template.md
@@ -34,4 +34,4 @@ component labels, Priority, milestone, Project status, and parent epic.
 
 ## Related Documents
 
-- [GitHub Project and Issue Standards](../../project/issue-standards.md)
+- [GitHub Project Standards](../../project/project-standards.md)

--- a/docs/plan/project/AGENTS.md
+++ b/docs/plan/project/AGENTS.md
@@ -1,14 +1,17 @@
 # GitHub Planning Standards Agent Guide
 
-This directory records the active GitHub issue metadata and Weavelit GitHub
-Project workflow values used to plan delivery. It provides a stable local
-reference while GitHub remains the source of truth for the live configuration.
+This directory records the active GitHub Issue and Pull Request metadata and
+Weavelit GitHub Project workflow values used to plan delivery. It provides a
+stable local reference while GitHub remains the source of truth for the live
+configuration.
 
 ## Purpose and Scope
 
 Use this section to understand what this directory owns, what it does not own, and where child paths own detailed rules.
 
-- This directory owns the documented standards for GitHub issue types, labels, organization-level Issue Fields, and Project status values.
+- This directory owns the documented standards for GitHub issue types, shared
+  Issue and Pull Request labels, GitHub Project fields, milestones, and Project
+  status values.
 - It does not own the live GitHub configuration; refresh the reference from the [Weavelit GitHub Project](https://github.com/orgs/JNTRE/projects/1/views/1) and the `JNTRE/weavelit` issue tracker.
 - The sibling `../issues/` directory owns open-issue snapshots, including the metadata values assigned to individual issues.
 
@@ -17,15 +20,18 @@ Use this section to understand what this directory owns, what it does not own, a
 Use this section as the source of truth for what assets belong in this directory and what each asset is for.
 
 - `AGENTS.md`: Local workflow, inventory, and documentation-boundary rules for GitHub planning standards.
-- `issue-standards.md`: Active GitHub issue-type, label, priority, and Project-status reference.
+- `project-standards.md`: Active GitHub Issue and Pull Request metadata and
+  Project workflow reference.
 
 ## Usage Guidance
 
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, `../../AGENTS.md`, and the repository-root `AGENTS.md`.
-- Refresh type, label, Issue Field, and Project status values from GitHub before changing `issue-standards.md`.
-- Preserve the exact configured name and capitalization of each GitHub value in `issue-standards.md`.
+- Refresh type, label, GitHub Project field, milestone, and Project status
+  values from GitHub before changing `project-standards.md`.
+- Preserve the exact configured name and capitalization of each GitHub value in
+  `project-standards.md`.
 - Update `../issues/issues.md` in the same change when a documented metadata change affects its standard record format or displayed values.
 - Record proposed GitHub configuration changes only after they are active in GitHub; do not present a proposal as an active standard.
 

--- a/docs/plan/project/project-standards.md
+++ b/docs/plan/project/project-standards.md
@@ -1,10 +1,17 @@
-# GitHub Project and Issue Standards
+# GitHub Project Standards
 
 This document records the active GitHub planning metadata for
 [JNTRE/weavelit](https://github.com/JNTRE/weavelit) and the
 [Weavelit GitHub Project](https://github.com/orgs/JNTRE/projects/1/views/1).
 GitHub remains the source of truth; update this reference when that configuration
 changes.
+
+## Metadata Scope
+
+These standards apply to GitHub Issues and Pull Requests where GitHub supports
+the metadata. Labels, GitHub Project fields, and milestones use the same
+configured values for both work-item types. Native issue types and issue
+relationships apply only to Issues.
 
 ## Issue Types
 
@@ -26,13 +33,13 @@ and issue relationships required for the work.
 
 ## Labels
 
-Apply the applicable component label to each issue. Add the general-purpose
-labels only when their defined condition applies; they do not replace the native
-issue type.
+Apply the applicable component label to each Issue or Pull Request. Add the
+general-purpose labels only when their defined condition applies; they do not
+replace a native issue type.
 
 ### Component Labels
 
-| Label | Apply when the issue affects |
+| Label | Apply when the Issue or Pull Request affects |
 | --- | --- |
 | `server core` | The Weavelit Server core. |
 | `database module` | An Application Database component. |
@@ -55,9 +62,9 @@ issue type.
 
 ## Priority
 
-`Priority` is an organization-level GitHub Issue Field that records the current
-importance level assigned to an issue. Set one of these exact values on each
-issue.
+`Priority` is an organization-level GitHub Project field that records the
+current importance of an Issue or Pull Request item. Set one of these exact
+values when the work item is added to the Project.
 
 | Priority |
 | --- |
@@ -69,7 +76,8 @@ issue.
 
 ## Project Status
 
-Set one of these exact `Status` values for each Project item.
+Set one of these exact `Status` values for each Issue or Pull Request Project
+item.
 
 | Status | Meaning |
 | --- | --- |
@@ -79,6 +87,12 @@ Set one of these exact `Status` values for each Project item.
 | `In review` | The item is in review. |
 | `done` | The item has been completed. |
 | `blocked` | The item cannot proceed until its blocker is resolved. |
+
+## Milestones
+
+Apply the relevant GitHub Milestone to an Issue or Pull Request when it belongs
+to a defined delivery milestone. Leave the milestone unset only when no
+milestone applies.
 
 ## Related Documents
 

--- a/docs/plan/project/project-standards.md
+++ b/docs/plan/project/project-standards.md
@@ -10,8 +10,8 @@ changes.
 
 These standards apply to GitHub Issues and Pull Requests where GitHub supports
 the metadata. Labels, GitHub Project fields, and milestones use the same
-configured values for both work-item types. Native issue types and issue
-relationships apply only to Issues.
+configured values for both work-item types. Native issue types,
+organization-level `Priority`, and issue relationships apply only to Issues.
 
 ## Issue Types
 
@@ -62,9 +62,8 @@ replace a native issue type.
 
 ## Priority
 
-`Priority` is an organization-level GitHub Project field that records the
-current importance of an Issue or Pull Request item. Set one of these exact
-values when the work item is added to the Project.
+`Priority` is an organization-level GitHub Issue Field that records the current
+importance assigned to an Issue. Set one of these exact values on each Issue.
 
 | Priority |
 | --- |

--- a/docs/server/AGENTS.md
+++ b/docs/server/AGENTS.md
@@ -22,6 +22,7 @@ Use this section as the source of truth for what assets belong in this directory
 - `audit/`: Documentation for the Server's accountability and Audit Log design.
 - `database/`: Documentation for Application Database backend boundaries and their implementation design.
 - `observability/`: Documentation for Server System Log design and future operational diagnosis.
+- `server-architecture-design.md`: Shared Server workspace, crate-composition, and lifecycle design rules.
 
 ## Usage Guidance
 

--- a/docs/server/database/application-database-design.md
+++ b/docs/server/database/application-database-design.md
@@ -19,10 +19,11 @@ Database backend is not a runtime **[Module](../../glossary.md#applications-and-
 
 The **[Weavelit Server](../../glossary.md#applications-and-interfaces)** owns
 backend composition and lifecycle. It reads the selected backend and its
-host-managed bootstrap configuration, validates that configuration, constructs
-the compiled-in backend, and calls it through the shared contract. A future
-backend independently selects its own connection and concurrency model behind
-that same contract.
+host-managed bootstrap configuration, validates the selected backend and common
+configuration structure, constructs the compiled-in backend, and calls it
+through the shared contract. Each backend validates its own connection and
+storage settings. A future backend independently selects its own connection and
+concurrency model behind that same contract.
 
 ## Initial Contract
 

--- a/docs/server/database/application-database-design.md
+++ b/docs/server/database/application-database-design.md
@@ -5,6 +5,89 @@ internal **[Application Database](../../glossary.md#applications-and-interfaces)
 backend contract. Backend-specific storage behavior belongs in the applicable
 child directory.
 
+## Crate Boundary
+
+`weavelit-server-database` defines the backend-neutral Application Database
+contract: Server domain types, the persistence operations available to the
+Server, and storage-neutral typed errors. It contains no backend selection,
+driver, connection, query, transaction, migration, or backup implementation.
+
+Each supported backend is a dedicated compiled-in implementation crate. The
+MVP SQLite implementation is `weavelit-server-database-sqlite`. It implements
+the shared contract and owns all SQLite-specific behavior. An Application
+Database backend is not a runtime **[Module](../../glossary.md#applications-and-interfaces)**.
+
+The **[Weavelit Server](../../glossary.md#applications-and-interfaces)** owns
+backend composition and lifecycle. It reads the selected backend and its
+host-managed bootstrap configuration, validates that configuration, constructs
+the compiled-in backend, and calls it through the shared contract. A future
+backend independently selects its own connection and concurrency model behind
+that same contract.
+
+## Initial Contract
+
+The initial contract expresses Server application intent rather than storage
+mechanics. It supports only these capabilities:
+
+1. Inspect whether the Application Database is initialized.
+2. Atomically persist the initial application-owned state exactly once.
+3. Load the initialized application-owned state required by Server startup.
+
+The initial write persists the complete supplied state and marks the database
+initialized as one operation. If it fails, no supplied state remains and the
+database stays uninitialized. A later initialization attempt returns the stable
+`AlreadyInitialized` error.
+
+The contract initially exposes these storage-neutral error categories:
+
+```text
+AlreadyInitialized
+NotInitialized
+InvalidState
+ConfigurationInvalid
+Unavailable
+IntegrityFailure
+```
+
+`ConfigurationInvalid` means that host-managed backend configuration must be
+corrected. `Unavailable` means an otherwise valid backend cannot currently be
+opened, queried, locked, or used. `IntegrityFailure` prevents normal operation
+when persisted data, schema, or migration history is damaged or incompatible.
+Backend-specific error details remain private and are mapped to these safe
+categories before reaching the Server.
+
+## Bootstrap And Operational State
+
+Host-managed bootstrap configuration identifies the compiled-in backend and
+its connection settings before the Server can open the Application Database;
+it remains outside the Application Database. Application-owned operational
+state is persisted through the contract, including durable Server configuration
+such as the listening IP address.
+
+**[Init](../../glossary.md#states-and-requests)** is a host-local
+**[Admin CLI](../../glossary.md#applications-and-interfaces)** workflow, not a
+network-exposed Server function. Post-Init administration changes operational
+state through its own authorized administration boundary and cannot rerun Init.
+
+## Log Module Separation
+
+Application Database persistence and **[Log Module](../../glossary.md#applications-and-interfaces)**
+destinations remain structurally and operationally separate, even when both
+use the same technology. They do not share application logic, crates, database
+files, schemas, migration ledgers, connections, health checks, configuration,
+resources, lifecycle, backup or recovery behavior, or retention policy.
+
+The Server rejects configuration where an Application Database file and a Log
+Module database file resolve to the same file. Log Modules receive only
+pre-redacted records from the Server; they never read or modify Application
+Database state. The Application Database never acts as a Log Module destination,
+fallback, or queue.
+
+Application Database selection and configuration occur in a distinct host-local
+Init step before Log Module selection and configuration. Selecting the same
+underlying technology for both does not reuse an Application Database backend
+or its resources.
+
 ## Backup And Recovery
 
 During **[Init](../../glossary.md#states-and-requests)**, the Server creates a
@@ -46,3 +129,7 @@ in an ordinary backup artifact.
 - [Security Model](../../security-model.md)
 - [Open Questions](../../open-questions.md)
 - [Glossary](../../glossary.md)
+- [Server Architecture Design](../server-architecture-design.md)
+- [SQLite Application Database Design](sqlite/sqlite-application-database-design.md)
+- [Log Module Design](../../log-modules/log-module-design.md)
+- [Testing and Validation Policy](../../testing.md)

--- a/docs/server/database/application-database-design.md
+++ b/docs/server/database/application-database-design.md
@@ -73,9 +73,11 @@ state through its own authorized administration boundary and cannot rerun Init.
 
 Application Database persistence and **[Log Module](../../glossary.md#applications-and-interfaces)**
 destinations remain structurally and operationally separate, even when both
-use the same technology. They do not share application logic, crates, database
-files, schemas, migration ledgers, connections, health checks, configuration,
-resources, lifecycle, backup or recovery behavior, or retention policy.
+use the same technology. They do not share Weavelit-owned persistence logic or
+implementation crates, database files, schemas, migration ledgers, connections,
+health checks, configuration, resources, lifecycle, backup or recovery behavior,
+or retention policy. They may use the same workspace-pinned third-party
+dependency, such as `rusqlite`, without sharing persistence behavior.
 
 The Server rejects configuration where an Application Database file and a Log
 Module database file resolve to the same file. Log Modules receive only

--- a/docs/server/database/sqlite/AGENTS.md
+++ b/docs/server/database/sqlite/AGENTS.md
@@ -22,6 +22,7 @@ Use this section to understand what this directory owns, what it does not own, a
 Use this section as the source of truth for what assets belong in this directory and what each asset is for.
 
 - `AGENTS.md`: Local routing, inventory, and documentation-boundary rules for the SQLite Application Database backend.
+- `sqlite-application-database-design.md`: SQLite driver, migration, transaction, connection-health, error, and test design.
 
 ## Usage Guidance
 

--- a/docs/server/database/sqlite/sqlite-application-database-design.md
+++ b/docs/server/database/sqlite/sqlite-application-database-design.md
@@ -1,0 +1,101 @@
+# SQLite Application Database Design
+
+This document defines the MVP SQLite implementation of the Server's internal
+**[Application Database](../../../glossary.md#applications-and-interfaces)**.
+It implements the shared backend contract in the
+[Application Database Design](../application-database-design.md).
+
+## Crate And Driver
+
+`weavelit-server-database-sqlite` is the dedicated SQLite implementation crate.
+It depends on `weavelit-server-database` and owns SQLite connectivity, explicit
+SQL, schema migrations, transaction behavior, connection health, and
+SQLite-specific error mapping. It does not own Server lifecycle decisions,
+shared contract types, or **[Log Module](../../../glossary.md#applications-and-interfaces)**
+destinations.
+
+The crate uses `rusqlite` with its `bundled` feature. The Server workspace
+centralizes and locks the selected dependency version. Bundling provides a
+known SQLite release and consistent behavior across development, CI, packaging,
+and deployment without relying on a host SQLite shared library.
+
+The backend uses explicit Weavelit-owned SQL and does not use an ORM. It does
+not enable runtime SQLite extension loading or execute user-supplied SQL.
+
+## Migrations And Transactions
+
+The crate embeds explicit, forward-only SQL migrations. Files use this immutable
+name format:
+
+```text
+NNNN_<action>_<subject>.sql
+```
+
+`NNNN` is a unique, zero-padded ascending sequence. Names use lowercase
+`snake_case`; `action` is one of `create`, `add`, `alter`, `migrate`, or
+`remove`; and `subject` describes the durable schema or data intent rather than
+SQL mechanics. For example:
+
+```text
+0001_create_application_state.sql
+0002_add_listening_address.sql
+0003_migrate_group_grants.sql
+```
+
+Released migrations are never edited, renamed, reordered, or reused. A
+correction is a new migration. A destructive or lossy `remove` migration
+requires a separately documented backup and compatibility decision.
+
+The SQLite database contains an Application Database-owned migration ledger of
+applied identifiers and checksums. On opening the backend, it validates ledger
+entries and applies pending migrations in ascending order. Each migration and
+its ledger entry run in one SQLite transaction. An unknown, missing, or
+checksum-mismatched applied migration is an integrity or compatibility failure:
+the backend changes nothing and refuses to report readiness.
+
+Each shared Application Database contract write is one SQLite transaction unless
+the contract explicitly defines a broader atomic workflow. A failed migration
+or write rolls back completely.
+
+## Connection And Health Behavior
+
+Each SQLite backend instance owns one SQLite connection for its lifetime and
+serializes access to it. The MVP does not use a connection pool. This is a
+SQLite-specific choice, not a constraint on a future Application Database
+backend.
+
+The backend enables foreign-key enforcement, write-ahead logging, and a bounded
+busy timeout. It applies and validates migrations before it is ready. A real,
+lightweight database query verifies connection health.
+
+Failure to open, migrate, validate, or query the Application Database prevents
+safe startup. The backend reports a typed, redacted contract error rather than
+a raw driver or filesystem error.
+
+## Errors And Test Evidence
+
+SQLite-specific errors are private implementation details. Before returning to
+the Server, the backend maps them to the shared contract's storage-neutral
+errors. Returned errors and ordinary diagnostics never include raw SQLite or
+operating-system messages, SQL, filesystem paths, connection settings, or
+secrets. Diagnostics may include deliberately redacted structured context such
+as a migration identifier.
+
+Integration tests use a new `tempfile` temporary directory and a real SQLite
+database file for each test. Tests reopen the file to verify persistence and
+allow the directory to remove database and WAL sidecar files automatically.
+They cover successful and idempotent migrations, restart persistence, migration
+and write rollback, invalid configuration, unavailable storage, incompatible
+migration history, and error and diagnostic redaction.
+
+The MVP scope does not defer quality obligations: every selected behavior has
+its required security, diagnostics, safe failure, and automated test evidence
+from the outset.
+
+## Related Documents
+
+- [Application Database Design](../application-database-design.md)
+- [Core Statements](../../../core-statements.md)
+- [Security Model](../../../security-model.md)
+- [Testing and Validation Policy](../../../testing.md)
+- [Log Module Design](../../../log-modules/log-module-design.md)

--- a/docs/server/server-architecture-design.md
+++ b/docs/server/server-architecture-design.md
@@ -57,8 +57,9 @@ contract or code.
 The **[Weavelit Server](../glossary.md#applications-and-interfaces)** composes
 supported **[Application Database](../glossary.md#applications-and-interfaces)**
 backends and runtime modules as compiled-in Rust crates. It owns backend and
-module selection, configuration validation, and lifecycle behavior; component
-crates own their implementation-specific behavior behind their documented
+module selection, common configuration validation, and lifecycle behavior.
+Component crates own their implementation-specific behavior, including
+validation of their connection and storage settings, behind their documented
 boundaries.
 
 A shared Server crate boundary must not erase the distinction between product

--- a/docs/server/server-architecture-design.md
+++ b/docs/server/server-architecture-design.md
@@ -1,0 +1,70 @@
+# Server Architecture Design
+
+This document records shared implementation-architecture decisions for the
+**[Weavelit Server](../glossary.md#applications-and-interfaces)**. It owns
+workspace-wide Rust crate structure, composition, and lifecycle rules that
+apply across Server components. Feature-specific design remains in its owning
+Server documentation boundary.
+
+## Scope And Ownership
+
+This document records decisions that affect more than one Server component,
+such as Rust workspace conventions, crate naming, compiled-in component
+composition, and shared lifecycle boundaries. It does not replace the detailed
+contract, storage, authentication, authorization, logging, or provider designs
+owned by their respective documents.
+
+A component-specific document links here when it applies a shared Server rule.
+A shared rule is recorded here only when it remains useful outside the component
+where the decision first arose.
+
+## Rust Crate Naming
+
+Internal Server Rust crates use this package-name convention:
+
+```text
+weavelit-server-<component>[-<specific-component>]
+```
+
+`<component>` names the Server concern. The optional
+`<specific-component>` names a concrete backend, destination, provider, or
+other implementation when applicable. Names use Cargo package spelling with
+hyphens; Rust imports use underscores.
+
+Create a base crate only when it owns meaningful shared code or a shared
+contract. An implementation crate may stand alone until a shared crate is
+justified. The naming convention does not classify a component as a Weavelit
+runtime **[Module](../glossary.md#applications-and-interfaces)**.
+
+For example, the Application Database crates are:
+
+```text
+weavelit-server-database
+weavelit-server-database-sqlite
+```
+
+The first crate owns the shared Application Database contract; the second owns
+the SQLite implementation. This convention also permits a future dedicated Log
+Module implementation crate such as `weavelit-server-log-sqlite`, without
+requiring a `weavelit-server-log` crate before it has a meaningful shared
+contract or code.
+
+## Compiled-In Component Boundaries
+
+The Server composes supported Application Database backends and Modules as
+compiled-in Rust crates. It owns backend and Module selection, configuration
+validation, and lifecycle behavior; component crates own their implementation-
+specific behavior behind their documented boundaries.
+
+A shared Server crate boundary must not erase the distinction between product
+concepts. In particular, an Application Database backend is not a runtime
+Module. Application Database persistence remains separate from every Log Module
+destination even when their implementations use the same technology.
+
+## Related Documents
+
+- [Core Statements](../core-statements.md)
+- [Glossary](../glossary.md)
+- [Application Database Design](database/application-database-design.md)
+- [Log Module Design](../log-modules/log-module-design.md)
+- [Testing and Validation Policy](../testing.md)

--- a/docs/server/server-architecture-design.md
+++ b/docs/server/server-architecture-design.md
@@ -8,7 +8,8 @@ Server documentation boundary.
 
 ## Scope And Ownership
 
-This document records decisions that affect more than one Server component,
+This document records decisions that affect more than one
+**[Weavelit Server](../glossary.md#applications-and-interfaces)** component,
 such as Rust workspace conventions, crate naming, compiled-in component
 composition, and shared lifecycle boundaries. It does not replace the detailed
 contract, storage, authentication, authorization, logging, or provider designs
@@ -33,10 +34,11 @@ hyphens; Rust imports use underscores.
 
 Create a base crate only when it owns meaningful shared code or a shared
 contract. An implementation crate may stand alone until a shared crate is
-justified. The naming convention does not classify a component as a Weavelit
-runtime **[Module](../glossary.md#applications-and-interfaces)**.
+justified. The naming convention does not classify a component as a runtime
+module.
 
-For example, the Application Database crates are:
+For example, the **[Application Database](../glossary.md#applications-and-interfaces)**
+crates are:
 
 ```text
 weavelit-server-database
@@ -44,22 +46,26 @@ weavelit-server-database-sqlite
 ```
 
 The first crate owns the shared Application Database contract; the second owns
-the SQLite implementation. This convention also permits a future dedicated Log
-Module implementation crate such as `weavelit-server-log-sqlite`, without
+the SQLite implementation. This convention also permits a future dedicated
+**[Log Module](../glossary.md#applications-and-interfaces)** implementation crate
+such as `weavelit-server-log-sqlite`, without
 requiring a `weavelit-server-log` crate before it has a meaningful shared
 contract or code.
 
 ## Compiled-In Component Boundaries
 
-The Server composes supported Application Database backends and Modules as
-compiled-in Rust crates. It owns backend and Module selection, configuration
-validation, and lifecycle behavior; component crates own their implementation-
-specific behavior behind their documented boundaries.
+The **[Weavelit Server](../glossary.md#applications-and-interfaces)** composes
+supported **[Application Database](../glossary.md#applications-and-interfaces)**
+backends and runtime modules as compiled-in Rust crates. It owns backend and
+module selection, configuration validation, and lifecycle behavior; component
+crates own their implementation-specific behavior behind their documented
+boundaries.
 
 A shared Server crate boundary must not erase the distinction between product
 concepts. In particular, an Application Database backend is not a runtime
-Module. Application Database persistence remains separate from every Log Module
-destination even when their implementations use the same technology.
+module. Application Database persistence remains separate from every
+**[Log Module](../glossary.md#applications-and-interfaces)** destination even
+when their implementations use the same technology.
 
 ## Related Documents
 


### PR DESCRIPTION
## Summary

Define the Application Database architecture needed to implement the MVP SQLite
backend safely, and align the repository's GitHub Project metadata standards
with the live GitHub configuration. The decisions establish the Server, shared
contract, and SQLite implementation boundaries, plus migration, transaction,
error, connection, test, and Log Module separation rules.

## Release Notes

- `docs(repo): define application database architecture`
- `docs(repo): align project metadata standards`
- `docs(repo): correct priority metadata scope`

### Issue Closure

Closes #6

## Impact

No runtime behavior changes. The documented database decisions guide follow-up
implementation issues #8 and #9. SQLite uses `rusqlite` with bundled SQLite,
explicit migrations, one serialized MVP connection, and isolated real-file
integration tests. Application Database and Log Module destinations remain
independent even when both use SQLite.

GitHub Project metadata standards now accurately distinguish metadata shared by
Issues and Pull Requests from the organization-level `Priority` Issue Field.

## Verification

- Validated canonical `/docs` repository-relative Markdown links with the
  documentation link-check script.
- Ran `git diff --check origin/dev...HEAD` successfully.
- Confirmed the affected Markdown files have no editor diagnostics.

## Documentation

- [Server Architecture Design](https://github.com/JNTRE/weavelit/blob/docs/application-database-design/docs/server/server-architecture-design.md)
- [Application Database Design](https://github.com/JNTRE/weavelit/blob/docs/application-database-design/docs/server/database/application-database-design.md)
- [SQLite Application Database Design](https://github.com/JNTRE/weavelit/blob/docs/application-database-design/docs/server/database/sqlite/sqlite-application-database-design.md)
- [Log Module Design](https://github.com/JNTRE/weavelit/blob/docs/application-database-design/docs/log-modules/log-module-design.md)
- [Core Statements](https://github.com/JNTRE/weavelit/blob/docs/application-database-design/docs/core-statements.md)
- [Glossary](https://github.com/JNTRE/weavelit/blob/docs/application-database-design/docs/glossary.md)
- [GitHub Project Standards](https://github.com/JNTRE/weavelit/blob/docs/application-database-design/docs/plan/project/project-standards.md)
- [Pull Request Template](https://github.com/JNTRE/weavelit/blob/docs/application-database-design/.github/pull_request_template.md)

## Checklist

- [x] This PR targets `dev`.
- [x] Applied the required label and GitHub Project fields.
- [x] Applied the relevant milestone, when one applies.
- [x] Confirmed the change is focused and the diff was reviewed.
- [x] Validated all relevant documentation and feature specifications are updated, when applicable.
- [x] Ran relevant checks, or explained why they could not be run.