### PR TITLE
Define server-owned Init boundary

### DIFF
--- a/docs/containers/dev/development-container-design.md
+++ b/docs/containers/dev/development-container-design.md
@@ -28,8 +28,9 @@ When implemented, the development image must:
   quality-gate suite;
 - keep non-secret development configuration outside the image and receive it
   through environment variables;
-- mount bootstrap secrets as read-only local files, never include them in the
-  build context, image layers, or environment variables; and
+- mount the versioned bootstrap configuration and bootstrap secrets as local
+  files, never include secrets in the build context, image layers, or
+  environment variables; and
 - use explicitly managed volumes for future persistent Server state and any
   optional build-cache data.
 
@@ -44,5 +45,6 @@ state, and secret mounts follow this design.
 
 - [Testing and Validation Policy](../../testing.md)
 - [Milestone 1](../../plan/milestones/milestone-1.md)
+- [Server Init Design](../../server/init-design.md)
 - [Production Container Design](../prod/production-container-design.md)
 - [Open Questions](../../open-questions.md)

--- a/docs/containers/prod/production-container-design.md
+++ b/docs/containers/prod/production-container-design.md
@@ -20,6 +20,8 @@ When implemented, the production image must:
 
 - run a verified packaged Server artifact without compiling source code at
   container startup;
+- run the Server and any bootstrap adapter as a dedicated non-root service
+  user, with mounted secret files readable only by that user;
 - exclude Rust, Cargo, source code, test tooling, and build dependencies;
 - document and test host administration, persistent state and backups, TLS
   termination, non-secret configuration, secret injection, provenance, upgrade,
@@ -31,4 +33,5 @@ When implemented, the production image must:
 
 - [Milestone 14](../../plan/milestones/milestone-14.md)
 - [Development Container Design](../dev/development-container-design.md)
+- [Server Init Design](../../server/init-design.md)
 - [Open Questions](../../open-questions.md)

--- a/docs/core-statements.md
+++ b/docs/core-statements.md
@@ -58,8 +58,9 @@ when its additional context is needed.
   supported operation.
 - Weavelit returns a structured result that an AI-assisted workflow can report
   and use.
-- Results include a correlation identifier; errors are structured, stable, and
-  never expose secrets or raw internal traces.
+- Results include a correlation identifier. A centralized Server-owned
+  presentation layer maps typed failures to structured, stable errors that
+  never expose secrets, raw internal traces, or dependency-specific details.
 - Weavelit fails safely when a request is invalid, unauthorized, duplicated,
   or cannot be completed.
 - A write operation must be safe to retry or protected against creating
@@ -225,12 +226,14 @@ when its additional context is needed.
   not a remotely callable Weavelit interface.
 - The Admin CLI supports interactive **[Init](glossary.md#states-and-requests)**
   and an explicit non-interactive bootstrap mode that reads a local bootstrap
-  configuration file. Both use the same Server-owned initialization logic.
-  Non-interactive bootstrap runs only against uninitialized Server state, reads
-  sensitive bootstrap values from local files referenced by the configuration
-  file rather than environment variables, and does not log or persist those
-  values or the bootstrap configuration. This non-interactive mode applies only
-  to Init; other Admin CLI functions remain host-local administrative actions.
+  configuration file. Both invoke the same Server-owned `InitializeServer` use
+  case in `weavelit-server-init`; the normal Server runtime does not expose an
+  Init interface. Non-interactive bootstrap uses versioned TOML, runs only
+  against uninitialized Server state, reads sensitive values only from local
+  files referenced by the configuration, and does not log or persist those
+  values or the configuration. This non-interactive mode applies only to Init;
+  other Admin CLI functions remain host-local administrative actions. The
+  detailed boundary is defined in the [Server Init Design](server/init-design.md).
 - **[Init](glossary.md#states-and-requests)**, creation of the
   **[Administrators Group](glossary.md#identities-and-access)**, creation of
   the first local **[Human User](glossary.md#identities-and-access)**, and
@@ -345,4 +348,5 @@ when its additional context is needed.
 - [Vision](vision.md)
 - [Security Model](security-model.md)
 - [Glossary](glossary.md)
+- [Server Init Design](server/init-design.md)
 - [Testing and Validation Policy](testing.md)

--- a/docs/plan/milestones/milestone-1.md
+++ b/docs/plan/milestones/milestone-1.md
@@ -7,7 +7,7 @@ Implementation progress is tracked in [GitHub Milestone 1](https://github.com/JN
 ## Goals
 
 - [ ] A **[Host Administrator](../../glossary.md#identities-and-access)** can use the **[Admin CLI](../../glossary.md#applications-and-interfaces)** to complete **[Init](../../glossary.md#states-and-requests)** interactively or from an explicit non-interactive bootstrap configuration file, create the **[Administrators Group](../../glossary.md#identities-and-access)**, create the first local **[Human User](../../glossary.md#identities-and-access)** without MFA enrollment, and add that user to the Administrators Group.
-- [ ] The non-interactive Admin CLI bootstrap uses the same Server-owned Init logic as interactive Init, runs only against uninitialized Server state, and reads sensitive bootstrap values only from local files referenced by its configuration file. It does not accept sensitive bootstrap values through environment variables or log or persist those values or the configuration.
+- [ ] The non-interactive Admin CLI bootstrap uses the shared Server-owned Init use case defined in the [Server Init Design](../../server/init-design.md): it uses versioned TOML, runs only against uninitialized Server state, reads sensitive bootstrap values only from referenced local files, rejects environment-secret input, and does not log or persist those values or the configuration.
 - [ ] The Administrators Group grants the Web UI **[Client Module](../../glossary.md#applications-and-interfaces)** and the **[Server Administration Permission](../../glossary.md#identities-and-access)**, but no named Operations.
 - [ ] The **[Weavelit Server](../../glossary.md#applications-and-interfaces)** applies default-deny authorization using additive Group grants and global availability gates. A disabled Human User, Client Module, **[Service Module](../../glossary.md#applications-and-interfaces)**, or **[Operation](../../glossary.md#applications-and-interfaces)** is unavailable regardless of otherwise effective Group grants.
 - [ ] A Host Administrator can use the Admin CLI to set the Weavelit Server listening IP address.
@@ -32,3 +32,4 @@ Implementation progress is tracked in [GitHub Milestone 1](https://github.com/JN
 - [Security Model](../../security-model.md)
 - [Glossary](../../glossary.md)
 - [Open Questions](../../open-questions.md)
+- [Server Init Design](../../server/init-design.md)

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -100,6 +100,12 @@ owning documentation when its additional context is needed.
   Administrator records the private recovery key outside Weavelit. The private
   recovery key is never stored in the Application Database, Server
   configuration, container volume, logs, or ordinary backup artifact.
+- Init bootstrap configuration contains no inline secret values or
+  environment-variable interpolation. It references secret files only; the
+  Server accepts a bounded regular non-symlink file without group or world
+  access and never logs the secret, its contents, or its path. The detailed
+  adapter and recovery-key delivery behavior is defined in the
+  [Server Init Design](server/init-design.md).
 - An encrypted backup may be created through server-administration functions
   and downloaded by an Administrator. The Server encrypts it for the recovery
   public key and does not expose the private recovery key during ordinary
@@ -153,3 +159,4 @@ owning documentation when its additional context is needed.
 
 - [Core Statements](core-statements.md)
 - [Glossary](glossary.md)
+- [Server Init Design](server/init-design.md)

--- a/docs/server/AGENTS.md
+++ b/docs/server/AGENTS.md
@@ -21,6 +21,7 @@ Use this section as the source of truth for what assets belong in this directory
 - `automation-identities/`: Documentation for **[Automation Identity](../glossary.md#identities-and-access)** lifecycle, ownership, and accountability design.
 - `audit/`: Documentation for the Server's accountability and Audit Log design.
 - `database/`: Documentation for Application Database backend boundaries and their implementation design.
+- `init-design.md`: Server-owned Init crate, adapter, bootstrap, secret-file, and error-boundary design.
 - `observability/`: Documentation for Server System Log design and future operational diagnosis.
 - `server-architecture-design.md`: Shared Server workspace, crate-composition, and lifecycle design rules.
 

--- a/docs/server/database/application-database-design.md
+++ b/docs/server/database/application-database-design.md
@@ -30,14 +30,21 @@ concurrency model behind that same contract.
 The initial contract expresses Server application intent rather than storage
 mechanics. It supports only these capabilities:
 
-1. Inspect whether the Application Database is initialized.
-2. Atomically persist the initial application-owned state exactly once.
-3. Load the initialized application-owned state required by Server startup.
+1. Inspect whether the Application Database is uninitialized,
+   `InitializationPending`, or initialized.
+2. Atomically create, reconcile, or discard a non-operational initialization
+   checkpoint containing a recovery public key and delivery nonce only.
+3. Atomically replace an eligible checkpoint with the complete
+   application-owned initial state exactly once.
+4. Load the initialized application-owned state required by Server startup.
 
 The initial write persists the complete supplied state and marks the database
-initialized as one operation. If it fails, no supplied state remains and the
-database stays uninitialized. A later initialization attempt returns the stable
-`AlreadyInitialized` error.
+initialized as one operation. A pending checkpoint is not application state and
+normal Server startup refuses to operate from it. It permits the Init crate to
+reconcile recovery-key output delivery without creating a new key pair or
+persisting bootstrap configuration. If the final write fails, the checkpoint
+remains available for the same Init workflow to resume or safely discard. A
+later initialization attempt returns the stable `AlreadyInitialized` error.
 
 The contract initially exposes these storage-neutral error categories:
 
@@ -69,10 +76,10 @@ such as the listening IP address.
 **[Admin CLI](../../glossary.md#applications-and-interfaces)** workflow, not a
 network-exposed Server function. Post-Init administration changes operational
 state through its own authorized administration boundary and cannot rerun Init.
-The Server-owned Init crate checks initialized state before accepting secrets,
-and the contract's atomic initial write returns `AlreadyInitialized` on every
-later attempt. The detailed Init workflow and adapter boundary are defined in
-the [Server Init Design](../init-design.md).
+The Server-owned preflight checks initialized state before interactive
+initialization secrets are accepted, and the contract's final atomic write
+returns `AlreadyInitialized` on every later attempt. The detailed Init workflow
+and adapter boundary are defined in the [Server Init Design](../init-design.md).
 
 ## Log Module Separation
 

--- a/docs/server/database/application-database-design.md
+++ b/docs/server/database/application-database-design.md
@@ -69,6 +69,10 @@ such as the listening IP address.
 **[Admin CLI](../../glossary.md#applications-and-interfaces)** workflow, not a
 network-exposed Server function. Post-Init administration changes operational
 state through its own authorized administration boundary and cannot rerun Init.
+The Server-owned Init crate checks initialized state before accepting secrets,
+and the contract's atomic initial write returns `AlreadyInitialized` on every
+later attempt. The detailed Init workflow and adapter boundary are defined in
+the [Server Init Design](../init-design.md).
 
 ## Log Module Separation
 
@@ -133,6 +137,7 @@ in an ordinary backup artifact.
 - [Open Questions](../../open-questions.md)
 - [Glossary](../../glossary.md)
 - [Server Architecture Design](../server-architecture-design.md)
+- [Server Init Design](../init-design.md)
 - [SQLite Application Database Design](sqlite/sqlite-application-database-design.md)
 - [Log Module Design](../../log-modules/log-module-design.md)
 - [Testing and Validation Policy](../../testing.md)

--- a/docs/server/init-design.md
+++ b/docs/server/init-design.md
@@ -14,6 +14,15 @@ request that it accepts. It owns bootstrap configuration processing,
 secret-file handling, Server semantic validation, recovery-key delivery, and
 the atomic initial-state transition.
 
+Before input collection, an adapter calls the crate's non-mutating
+`PreflightInitializeServer` helper with the selected backend and the minimum
+connection configuration needed to open it. It returns an opaque preflight
+handle only when the target is eligible for Init. The handle is bound to the
+selected Application Database and is supplied to `InitializeServer`, which
+rechecks eligibility during its final atomic state transition. Preflight is not
+an alternative initialization path and cannot create or modify application
+state.
+
 The normal `weavelit-server` runtime does not depend on
 `weavelit-server-init` and does not expose an Init interface. It opens existing
 application state for normal operation and does not start normally when that
@@ -23,8 +32,8 @@ The **[Admin CLI](../glossary.md#applications-and-interfaces)** is a host-local
 adapter. It owns command parsing, interactive prompts, and presentation of
 normalized results. It has no direct Application Database or driver access and
 cannot create an alternative initialization path. Interactive prompts and
-non-interactive bootstrap both create the same normalized request and invoke
-`InitializeServer`.
+non-interactive bootstrap both first use Server-owned preflight, then create the
+same normalized request and invoke `InitializeServer`.
 
 A future container bootstrap adapter passes its mounted bootstrap-configuration
 path to `weavelit-server-init`. It reuses the same parser, secret-file rules,
@@ -52,6 +61,14 @@ never reads bootstrap secrets from environment variables. Unrelated non-secret
 environment configuration remains valid; a future explicitly named secret
 environment variable is unsupported and must be rejected rather than read.
 
+Preflight reads only the selected backend's non-sensitive configuration. When a
+future backend cannot be opened without a secret, the Init crate may read only
+the referenced connection secret needed for that opening; the adapter never
+reads it. For the MVP SQLite backend, preflight needs no secret. After preflight
+accepts the target, the adapter may collect the initial Administrator password,
+Log Module credentials, and other initialization secrets. An already initialized
+target therefore rejects before those values are prompted for or read.
+
 ## Secret Files And Recovery-Key Delivery
 
 The Init crate accepts a secret file only when the opened object is a
@@ -69,15 +86,33 @@ Server process can read the file and it is not group- or world-accessible.
 During Init, the Server generates a backup recovery key pair and retains only
 the public key. Interactive Init may display the private key once after an
 explicit confirmation. Non-interactive bootstrap requires an explicit output
-file, creates it only when it does not already exist, applies restrictive
-permissions, and writes the private key once without printing or logging it.
-Future container bootstrap uses the same mounted output-file mechanism.
+file and never prints or logs the private key. Future container bootstrap uses
+the same mounted output-file mechanism.
+
+Recovery-key delivery and initialization use a recoverable two-phase protocol:
+
+1. The Init crate creates a restrictive, unique staging file beside the requested
+   output path, writes and synchronizes the private key, and records an
+   `InitializationPending` checkpoint containing only the public key and a
+   delivery nonce. Normal Server startup treats this checkpoint as uninitialized.
+2. It finalizes the staging file at the requested output path without replacing
+   an existing file, then atomically replaces the checkpoint with the complete
+   initialized state.
+
+If a delivery or final-state write fails, the checkpoint prevents a new key pair
+from being generated. A retry using the same output path verifies the staged or
+final key against the pending public key and resumes the same `InitializeServer`
+workflow. If neither delivery file remains, the crate safely discards the
+non-operational checkpoint before beginning a new attempt. It never marks the
+Server initialized before private-key delivery succeeds, and it never overwrites
+an unrelated output file.
 
 ## Initialization Lifecycle And Errors
 
-Init identifies and opens the configured **[Application Database](../glossary.md#applications-and-interfaces)** before collecting interactive secrets or reading
-referenced secret files. If the database is already initialized,
-`InitializeServer` returns `AlreadyInitialized` without changing state.
+`PreflightInitializeServer` identifies and opens the configured
+**[Application Database](../glossary.md#applications-and-interfaces)** before
+interactive initialization secrets are collected or read. If the database is
+already initialized, it returns `AlreadyInitialized` without changing state.
 
 The complete application-owned initial state commits atomically. A failure in
 validation, recovery-key generation, Log Module setup, durable Audit Log
@@ -96,10 +131,11 @@ operating-system errors never reach users or automation.
 
 ## Test Evidence
 
-`weavelit-server-init` has direct tests for normalized-request validation,
-TOML parsing and version rejection, secret-file safety, environment rejection,
-recovery-key delivery, redaction, atomic rollback, retry behavior, and the
-one-time `AlreadyInitialized` guard.
+`weavelit-server-init` has direct tests for preflight-before-prompt behavior,
+normalized-request validation, TOML parsing and version rejection, secret-file
+safety, environment rejection, recovery-key staging and reconciliation,
+redaction, atomic rollback, retry behavior, and the one-time
+`AlreadyInitialized` guard.
 
 Admin CLI process-level tests verify interactive and bootstrap command wiring,
 stable normalized error output, and high-risk rejection cases. Interactive

--- a/docs/server/init-design.md
+++ b/docs/server/init-design.md
@@ -1,0 +1,122 @@
+# Server Init Design
+
+This document defines the Server-owned implementation boundary for
+**[Init](../glossary.md#states-and-requests)**. It makes interactive,
+host-local bootstrap, and future container bootstrap adapters invoke one
+initialization workflow while keeping Server validation, secret handling, and
+state changes outside those adapters.
+
+## Crate And Adapter Boundary
+
+`weavelit-server-init` is the dedicated Server-owned crate for initialization.
+It exposes one named `InitializeServer` use case and the normalized in-memory
+request that it accepts. It owns bootstrap configuration processing,
+secret-file handling, Server semantic validation, recovery-key delivery, and
+the atomic initial-state transition.
+
+The normal `weavelit-server` runtime does not depend on
+`weavelit-server-init` and does not expose an Init interface. It opens existing
+application state for normal operation and does not start normally when that
+state is absent or invalid.
+
+The **[Admin CLI](../glossary.md#applications-and-interfaces)** is a host-local
+adapter. It owns command parsing, interactive prompts, and presentation of
+normalized results. It has no direct Application Database or driver access and
+cannot create an alternative initialization path. Interactive prompts and
+non-interactive bootstrap both create the same normalized request and invoke
+`InitializeServer`.
+
+A future container bootstrap adapter passes its mounted bootstrap-configuration
+path to `weavelit-server-init`. It reuses the same parser, secret-file rules,
+and use case without depending on Admin CLI presentation code.
+
+## Bootstrap Configuration
+
+Non-interactive bootstrap uses a human-authored TOML file. Its top-level
+`format_version` field is required. Unsupported versions fail safely rather
+than being inferred or partially interpreted.
+
+The configuration contains non-sensitive operational values and typed
+secret-file references only. Secret-bearing fields are represented by
+`SecretFileReference` values, exposed as TOML `*_file` fields. Inline secret
+values, secret encodings, and environment-variable interpolation are rejected.
+
+The initial Administrator password, Log Module credentials, future Application
+Database credentials, and any host-supplied private keys or certificates are
+secret-bearing values. The generated backup recovery private key is not
+bootstrap input.
+
+`weavelit-server-init` owns bootstrap schema parsing, structural validation,
+secret-file reference handling, and conversion to the normalized request. It
+never reads bootstrap secrets from environment variables. Unrelated non-secret
+environment configuration remains valid; a future explicitly named secret
+environment variable is unsupported and must be rejected rather than read.
+
+## Secret Files And Recovery-Key Delivery
+
+The Init crate accepts a secret file only when the opened object is a
+bounded-size regular non-symlink file with no group or world access. It
+defensively verifies the opened file, reads UTF-8 content once, trims at most
+one final newline, and never logs the secret, its contents, or its path.
+
+The shared rule does not require a specific file owner. In a future production
+container, the Server and any bootstrap adapter run as a dedicated non-root
+service user; mounted secret files are readable only by that user. Packaged
+host deployments leave service-account and file-owner choices to the
+**[Host Administrator](../glossary.md#identities-and-access)**, provided the
+Server process can read the file and it is not group- or world-accessible.
+
+During Init, the Server generates a backup recovery key pair and retains only
+the public key. Interactive Init may display the private key once after an
+explicit confirmation. Non-interactive bootstrap requires an explicit output
+file, creates it only when it does not already exist, applies restrictive
+permissions, and writes the private key once without printing or logging it.
+Future container bootstrap uses the same mounted output-file mechanism.
+
+## Initialization Lifecycle And Errors
+
+Init identifies and opens the configured **[Application Database](../glossary.md#applications-and-interfaces)** before collecting interactive secrets or reading
+referenced secret files. If the database is already initialized,
+`InitializeServer` returns `AlreadyInitialized` without changing state.
+
+The complete application-owned initial state commits atomically. A failure in
+validation, recovery-key generation, Log Module setup, durable Audit Log
+validation, or persistence leaves the Server uninitialized and safely
+retryable. A non-application destination may retain an artifact such as an
+empty Log Module file; its cleanup behavior belongs to its module design.
+
+All Init failures use the Server's centralized, typed error presentation.
+Interactive and bootstrap modes provide actionable, redacted output. Bootstrap
+also provides a stable machine-readable category and defined nonzero exit
+status. The initial categories are `already_initialized`,
+`configuration_invalid`, `secret_file_unsafe`, `secret_file_unavailable`,
+`storage_unavailable`, `storage_integrity_failure`, and
+`initialization_failed`. Raw Rust, dependency, SQL, filesystem, and
+operating-system errors never reach users or automation.
+
+## Test Evidence
+
+`weavelit-server-init` has direct tests for normalized-request validation,
+TOML parsing and version rejection, secret-file safety, environment rejection,
+recovery-key delivery, redaction, atomic rollback, retry behavior, and the
+one-time `AlreadyInitialized` guard.
+
+Admin CLI process-level tests verify interactive and bootstrap command wiring,
+stable normalized error output, and high-risk rejection cases. Interactive
+tests use a testable input/output abstraction rather than a real terminal; the
+selected no-echo terminal facility receives focused integration coverage.
+Application Database integration tests verify atomic one-time persistence. A
+future container bootstrap adapter has mount-based smoke tests while reusing
+the same Init crate.
+
+## Related Documents
+
+- [Core Statements](../core-statements.md)
+- [Security Model](../security-model.md)
+- [Server Architecture Design](server-architecture-design.md)
+- [Application Database Design](database/application-database-design.md)
+- [Log Module Design](../log-modules/log-module-design.md)
+- [Development Container Design](../containers/dev/development-container-design.md)
+- [Production Container Design](../containers/prod/production-container-design.md)
+- [Testing and Validation Policy](../testing.md)
+- [Milestone 1](../plan/milestones/milestone-1.md)

--- a/docs/server/server-architecture-design.md
+++ b/docs/server/server-architecture-design.md
@@ -52,6 +52,11 @@ such as `weavelit-server-log-sqlite`, without
 requiring a `weavelit-server-log` crate before it has a meaningful shared
 contract or code.
 
+`weavelit-server-init` is the dedicated Server-owned crate for the shared Init
+use case. It is not a runtime module and is not linked into the normal
+`weavelit-server` runtime. Its detailed adapter and lifecycle boundary is
+defined in the [Server Init Design](init-design.md).
+
 ## Compiled-In Component Boundaries
 
 The **[Weavelit Server](../glossary.md#applications-and-interfaces)** composes
@@ -154,6 +159,7 @@ impact, and validation performed.
 
 - [Core Statements](../core-statements.md)
 - [Glossary](../glossary.md)
+- [Server Init Design](init-design.md)
 - [Application Database Design](database/application-database-design.md)
 - [Log Module Design](../log-modules/log-module-design.md)
 - [Testing and Validation Policy](../testing.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -39,6 +39,7 @@ Each change must include the tests appropriate to its risk and boundary:
 | Database, filesystem, configuration, serialization, or process behavior | Integration tests using isolated temporary resources and real adapters. |
 | Versioned API, **[Client Module](glossary.md#applications-and-interfaces)**, or **[Service Module](glossary.md#applications-and-interfaces)** contract | Contract tests for accepted requests and stable success and error responses. |
 | Authentication, authorization, secret handling, audit logging, MFA, or destructive operations | Tests for every allowed and denied path, plus tests that sensitive values are absent from returned errors and logs. |
+| Server-owned Init use case or bootstrap adapter | Direct workflow tests for validation, one-time atomic persistence, retry, redaction, and secret-file rejection; process-level tests for each supplied adapter's command or mount workflow. |
 | Provider integration | Tests against controlled fakes or recorded fixtures for request construction, error mapping, retry, rate-limit, and duplicate-protection behavior. Live-provider checks are separately controlled smoke tests, never the default test suite. |
 | Web UI, Weavelit CLI, Admin CLI, packaging, or deployment workflow | Focused end-to-end or smoke tests of the user workflow and the failure condition most likely to cause an unusable release. |
 
@@ -138,3 +139,4 @@ tests to a final hardening phase.
 - [Core Statements](core-statements.md)
 - [Security Model](security-model.md)
 - [Glossary](glossary.md)
+- [Server Init Design](server/init-design.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -39,7 +39,7 @@ Each change must include the tests appropriate to its risk and boundary:
 | Database, filesystem, configuration, serialization, or process behavior | Integration tests using isolated temporary resources and real adapters. |
 | Versioned API, **[Client Module](glossary.md#applications-and-interfaces)**, or **[Service Module](glossary.md#applications-and-interfaces)** contract | Contract tests for accepted requests and stable success and error responses. |
 | Authentication, authorization, secret handling, audit logging, MFA, or destructive operations | Tests for every allowed and denied path, plus tests that sensitive values are absent from returned errors and logs. |
-| Server-owned Init use case or bootstrap adapter | Direct workflow tests for validation, one-time atomic persistence, retry, redaction, and secret-file rejection; process-level tests for each supplied adapter's command or mount workflow. |
+| Server-owned Init use case or bootstrap adapter | Direct workflow tests for preflight-before-prompt behavior, validation, one-time atomic persistence, recovery-key delivery reconciliation, retry, redaction, and secret-file rejection; process-level tests for each supplied adapter's command or mount workflow. |
 | Provider integration | Tests against controlled fakes or recorded fixtures for request construction, error mapping, retry, rate-limit, and duplicate-protection behavior. Live-provider checks are separately controlled smoke tests, never the default test suite. |
 | Web UI, Weavelit CLI, Admin CLI, packaging, or deployment workflow | Focused end-to-end or smoke tests of the user workflow and the failure condition most likely to cause an unusable release. |
 


### PR DESCRIPTION
# Summary

Define the Server-owned Init boundary shared by interactive Admin CLI and non-interactive bootstrap workflows. Add the canonical design for the dedicated `weavelit-server-init` crate, versioned TOML bootstrap input, secret-file handling, one-time initialization, normalized errors, recovery-key delivery, and test evidence.

## Release Notes

- `docs(repo): define server-owned init boundary`

### Issue Closure

Closes #7

## Impact

Establishes the documented contract for future Init implementation. Bootstrap configuration uses versioned TOML and accepts sensitive values only through safe local secret-file references. Future production containers must run the Server and bootstrap adapter as a dedicated non-root service user. No runtime behavior or migration is included in this documentation-only change.

## Verification

- Markdown diagnostics reported no errors for all changed documentation files.
- `git diff --check`
- `git diff --check origin/dev...HEAD`

## Documentation

- [Server Init Design](docs/server/init-design.md)
- [Server Architecture Design](docs/server/server-architecture-design.md)
- [Application Database Design](docs/server/database/application-database-design.md)
- [Security Model](docs/security-model.md)
- [Testing and Validation Policy](docs/testing.md)

## Checklist

- [x] This PR targets `dev`.
- [x] Applied the `server core` label and Weavelit Project `in progress` status from Issue #7.
- [x] Applied the `Milestone 1: Core Server Application` milestone from Issue #7.
- [x] Confirmed the change is focused and the diff was reviewed.
- [x] Validated all relevant documentation and feature specifications are updated, when applicable.
- [x] Ran relevant checks, or explained why they could not be run.
