### PR TITLE
Add shared documentation standards

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -23,6 +23,7 @@ Use this section as the source of truth for what assets belong in this directory
 - `clients/`: Documentation for individual client applications, including the **[Weavelit CLI](glossary.md#applications-and-interfaces)** and **[Web UI](glossary.md#applications-and-interfaces)**.
 - `containers/`: Development and production OCI container-image documentation.
 - `core-statements.md`: Current product, security, and technical truths; expand or replace statements only after a clear decision.
+- `documentation-standards.md`: Shared authority, document-type, lifecycle, structure, and writing standards for production documentation under `docs/`.
 - `glossary.md`: Canonical definitions for Weavelit applications, interfaces, identities, access, states, and requests.
 - `log-modules/`: Documentation for server-side **[Log Modules](glossary.md#applications-and-interfaces)** that persist or deliver System Logs and Audit Logs.
 - `mfa-modules/`: Documentation for server-side **[MFA Modules](glossary.md#applications-and-interfaces)** and their method-specific enrollment, verification, and protected factor-data handling.
@@ -39,6 +40,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Make minimal, targeted edits; avoid broad rewrites unless explicitly requested.
 - Use `glossary.md` for canonical terms and keep their usage consistent across the documentation.
 - Record settled product, security, or technical commitments in `core-statements.md`; remove a resolved item from `open-questions.md` and place its decision in the appropriate canonical document or an architecture decision record.

--- a/docs/client-modules/AGENTS.md
+++ b/docs/client-modules/AGENTS.md
@@ -24,6 +24,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Place shared Client Module documentation directly in this folder; place module-specific detail in its appropriate child directory.
 - Preserve the future-only status of `mcp/`; do not add implementation artifacts or describe it as currently supported.
 - Use `../glossary.md` for canonical terminology and link to its owning category rather than restating canonical definitions.

--- a/docs/client-modules/mcp/AGENTS.md
+++ b/docs/client-modules/mcp/AGENTS.md
@@ -21,6 +21,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, then `../../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Do not add implementation artifacts or describe MCP as supported; add design documentation only after the relevant product decision is recorded in a canonical document.
 - Keep shared Client Module material in the parent `../` directory and use `../../glossary.md` for canonical terminology.
 - Make minimal, targeted changes and update this inventory when assets are added, removed, renamed, or moved.

--- a/docs/client-modules/weavelit-cli/AGENTS.md
+++ b/docs/client-modules/weavelit-cli/AGENTS.md
@@ -21,6 +21,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, then `../../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Keep Weavelit CLI Client Module documentation directly in this folder; move shared Client Module material to the parent `../` directory.
 - Use `../../glossary.md` for canonical terminology and link to its owning category rather than restating canonical definitions.
 - Make minimal, targeted changes and update this inventory when assets are added, removed, renamed, or moved.

--- a/docs/client-modules/web-ui/AGENTS.md
+++ b/docs/client-modules/web-ui/AGENTS.md
@@ -21,6 +21,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, then `../../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Keep Web UI Client Module documentation directly in this folder; move shared Client Module material to the parent `../` directory.
 - Use `../../glossary.md` for canonical terminology and link to its owning category rather than restating canonical definitions.
 - Make minimal, targeted changes and update this inventory when assets are added, removed, renamed, or moved.

--- a/docs/clients/AGENTS.md
+++ b/docs/clients/AGENTS.md
@@ -24,6 +24,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing this directory, read this `AGENTS.md`, then `../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Place documentation shared by client applications and adapters directly in this folder; place component-specific detail in its child directory.
 - Preserve the future-only status of `mcp/`; do not add implementation artifacts or describe it as currently supported.
 - Use `../glossary.md` for canonical terminology and link to its owning category rather than restating canonical definitions.

--- a/docs/clients/mcp/AGENTS.md
+++ b/docs/clients/mcp/AGENTS.md
@@ -21,6 +21,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, then `../../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Do not add implementation artifacts or describe MCP as supported; add design documentation only after the relevant product decision is recorded in a canonical document.
 - Keep shared client material in the parent `../` directory and use `../../glossary.md` for canonical terminology.
 - Make minimal, targeted changes and update this inventory when assets are added, removed, renamed, or moved.

--- a/docs/clients/weavelit-cli/AGENTS.md
+++ b/docs/clients/weavelit-cli/AGENTS.md
@@ -21,6 +21,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, then `../../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Keep Weavelit CLI-specific material directly in this folder; move shared client-application material to the parent `../` directory.
 - Use `../../glossary.md` for canonical terminology and link to its owning category rather than restating canonical definitions.
 - Make minimal, targeted changes and update this inventory when assets are added, removed, renamed, or moved.

--- a/docs/clients/web-ui/AGENTS.md
+++ b/docs/clients/web-ui/AGENTS.md
@@ -21,6 +21,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, then `../../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Keep Web UI-specific material directly in this folder; move shared client-application material to the parent `../` directory.
 - Use `../../glossary.md` for canonical terminology and link to its owning category rather than restating canonical definitions.
 - Make minimal, targeted changes and update this inventory when assets are added, removed, renamed, or moved.

--- a/docs/containers/AGENTS.md
+++ b/docs/containers/AGENTS.md
@@ -31,6 +31,9 @@ Follow this section for workflow, sequencing, and decision order when making cha
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md` and the
   repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the
+  [Documentation Standards](../documentation-standards.md) and apply its
+  authority, document-type, lifecycle, structure, and writing rules.
 - Keep the development image and production OCI image as separate artifacts;
   do not make production behavior a development-image mode.
 - Preserve OCI-compatible image contracts. Docker may be documented as a local

--- a/docs/containers/dev/AGENTS.md
+++ b/docs/containers/dev/AGENTS.md
@@ -28,6 +28,7 @@ Follow this section for workflow, sequencing, and decision order when making cha
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, `../../AGENTS.md`,
   and the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Update this documentation when the matching development Containerfile or its
   build, mount, configuration, or validation contract changes.
 - Keep Docker as a supported local client without requiring Docker-only image or

--- a/docs/containers/prod/AGENTS.md
+++ b/docs/containers/prod/AGENTS.md
@@ -27,6 +27,7 @@ Follow this section for workflow, sequencing, and decision order when making cha
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, `../../AGENTS.md`,
   and the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Update this documentation when the matching production Containerfile or its
   packaging, runtime, deployment, or release-validation contract changes.
 - Keep the production image limited to the same versioned, prebuilt Server

--- a/docs/documentation-standards.md
+++ b/docs/documentation-standards.md
@@ -1,0 +1,228 @@
+# Weavelit Documentation Standards
+
+This document defines the shared structure, writing, ownership, and maintenance
+standards for production documentation under `docs/`. It gives documents a
+consistent contract without forcing product references, implementation designs,
+planning records, and decision records into one template.
+
+These standards supplement the routing and boundary rules in the applicable
+`AGENTS.md` files. They do not govern the structure or maintenance process of
+`AGENTS.md` files themselves.
+
+## Document Authority
+
+Every subject has one authoritative document. The authoritative document owns
+the meaning of a decision, requirement, contract, definition, or delivery
+outcome and is the location where that meaning changes.
+
+A document that depends on another document's authority must link to it. It may
+briefly state the local consequence needed to make its own design or outcome
+understandable, but it must not create a second independently maintained version
+of the source material. When the authoritative statement changes, update its
+affected consequences and links in the same change.
+
+Use these ownership boundaries:
+
+- `vision.md` owns the high-level product purpose and system relationships.
+- `core-statements.md` owns cross-cutting settled product and technical truths.
+- `security-model.md` owns cross-cutting security requirements and constraints.
+- `glossary.md` owns canonical terminology and definitions.
+- `open-questions.md` owns unresolved product and architecture decisions.
+- Component and module design documents own implementation-specific contracts,
+  invariants, lifecycle behavior, failure behavior, and technical choices.
+- Planning documents own delivery outcomes and work organization, not the
+  product or technical decisions on which those outcomes depend.
+- Architecture decision records own the rationale and consequences of a
+  consequential decision when preserving that history remains useful after the
+  current design has incorporated the result.
+
+## Shared Document Contract
+
+Every production document must:
+
+1. Use one level-one heading that identifies its subject.
+2. Establish its purpose and authority in the opening paragraph or opening
+   section.
+3. State exclusions when a nearby document could reasonably appear to own the
+   same material.
+4. Organize content by the reader's questions and the subject's boundaries,
+   not by the order in which decisions or implementation work occurred.
+5. Use the canonical terms and first-substantive-use glossary links required by
+   the applicable documentation guidance.
+6. Keep each requirement, decision, or definition in one authoritative location
+   and link to it elsewhere.
+7. End with a `## Related Documents` section containing only current,
+   repository-relative links to directly relevant canonical documents.
+
+The opening does not require a heading when a short introductory paragraph
+states the document's purpose and authority clearly. Add a dedicated `Scope`,
+`Purpose`, or `Scope And Ownership` section when exclusions, parent-child
+ownership, or applicability need more than a short paragraph.
+
+## Document Types
+
+Choose a document type from the information it owns. A document may combine
+closely related profiles when one coherent authority genuinely requires it, but
+must be split when the profiles begin to change independently.
+
+### Canonical Product And Policy Documents
+
+Canonical product and policy documents define current product truths,
+cross-cutting requirements, terminology, or repository-wide policy. Their
+structure follows the concepts they own rather than a fixed heading template.
+
+They must distinguish current binding material from maintenance instructions
+and future intent. When implementation gives a component clear ownership of
+specific detail, move that detail to the component's design document and retain
+only the cross-cutting rule and an authoritative link.
+
+### Component And Module Design Documents
+
+Design documents explain how one defined boundary satisfies product, security,
+and technical requirements. They must identify:
+
+- the component, module, contract, or lifecycle they own;
+- important behavior or material explicitly outside that ownership;
+- externally observable success, rejection, and failure behavior where
+  applicable;
+- security, persistence, compatibility, or lifecycle invariants relevant to
+  the boundary; and
+- validation obligations when the design introduces behavior not already
+  covered by the Testing and Validation Policy.
+
+Design documents describe the intended implementation contract, not a tour of
+source files or a chronological implementation journal. Use code identifiers
+when they are part of a stable contract or make the boundary materially clearer.
+
+### Planning And Milestone Documents
+
+Planning documents define observable delivery outcomes, sequencing, and work
+organization. They may summarize a canonical requirement when needed to make a
+completion outcome independently checkable, but the summary must link to its
+authority and must not change or extend that requirement.
+
+A milestone goal describes a capability, limit, protection, safe rejection, or
+verification result. It does not decompose the outcome into an exhaustive list
+of implementation tasks. Completion requires both the behavior and the evidence
+required by the Testing and Validation Policy.
+
+### Open Questions
+
+An open question records a decision that is genuinely unresolved and whose
+answer affects product behavior, architecture, security, operations, or a
+public contract. State the decision to be made and enough settled context to
+bound it without presenting an undecided option as current truth.
+
+When resolved, remove the question and record the result in its authoritative
+canonical or design document. Create an architecture decision record as well
+when the rejected alternatives, rationale, or migration consequences will
+remain important to future work.
+
+### Architecture Decision Records
+
+Use an architecture decision record for a consequential choice when future
+maintainers will need to understand why it was made, which alternatives were
+rejected, or what would be required to reverse it. Do not create one for routine
+implementation details whose rationale is clear in the owning design.
+
+An architecture decision record must contain:
+
+- `Status`: proposed, accepted, superseded, or rejected;
+- `Context`: the forces, constraints, and decision being addressed;
+- `Decision`: the selected direction;
+- `Consequences`: important benefits, costs, constraints, and follow-up work;
+  and
+- `Related Documents`: links to the current documents that apply the decision.
+
+An accepted record preserves decision history; the owning canonical or design
+document remains the authority for current behavior. A superseded record links
+to the replacing record or current authority and is not rewritten to appear
+current.
+
+### Templates And Operational References
+
+Templates define the information required to create another artifact. Use
+explicit placeholders and instructions that are removed or replaced when the
+artifact is created. Operational references define a repeatable repository or
+project process and should favor ordered procedures, exact field definitions,
+and verifiable outcomes over explanatory narrative.
+
+## Document Lifecycle
+
+Production documentation is either active, future, proposed, deprecated, or
+superseded. Active is the default and requires no status label.
+
+- A `Future` document reserves an already approved documentation boundary for
+  behavior that is not implemented. It must not imply current availability.
+- A `Proposed` document describes material that is under review and not yet a
+  binding decision.
+- A `Deprecated` document remains temporarily relevant but has a named
+  replacement or removal condition.
+- A `Superseded` document is retained for history and links to the authority
+  that replaced it.
+
+Place a non-active status immediately after the title or introductory paragraph
+so it cannot be mistaken for current behavior. State the implication in plain
+language, including where current authority remains when applicable. Do not use
+dates, version fields, owners, or other metadata unless a repository process
+actively maintains and consumes them.
+
+Documentation describes current intended behavior in the present tense. Use
+future tense only for explicitly future or proposed material. Do not infer that
+a documented design is implemented; implementation status belongs in planning
+and project systems unless the document's purpose specifically owns it.
+
+## Structure And Splitting
+
+Structure a document around coherent concepts whose headings help a reader
+locate an answer directly. Prefer focused sections and descriptive headings over
+long narrative passages. A heading should name the subject beneath it, not use
+generic labels such as `Details`, `Other`, or `Notes` when a precise name is
+available.
+
+Review a document for splitting when any of these conditions is true:
+
+- a section belongs to a different folder-level ownership boundary;
+- a section changes independently from the rest of the document;
+- a section has a distinct lifecycle, status, or primary audience;
+- other documents repeatedly need to link directly to that section;
+- keeping the section in place causes its requirements or decisions to be
+  repeated elsewhere; or
+- the document mixes canonical policy, component design, and delivery planning
+  in ways that obscure which statements are authoritative.
+
+Length alone does not require a split. Treat substantial growth as a prompt to
+review cohesion, ownership, and navigation. Do not split a coherent document
+into fragments that force readers or agents to assemble one contract from many
+small files.
+
+When extracting material, move its full authority to the new document. Replace
+the old material with only the context and link needed to preserve navigation,
+then update affected links and asset inventories through their established
+maintenance process.
+
+## Writing Style
+
+- Write direct, declarative statements and use normative words consistently:
+  `must` for requirements, `must not` for prohibitions, `may` for permitted
+  choices, and `should` for recommendations with valid exceptions.
+- Distinguish requirements from examples. Introduce examples as examples so
+  they cannot be mistaken for an exhaustive contract.
+- Define acronyms on first substantive use unless they are canonical glossary
+  terms or universally clear in the immediate technical context.
+- Use lists for genuinely parallel items, tables for comparable structured
+  facts, and prose for relationships and rationale.
+- Keep heading levels sequential and avoid sections that contain only a link to
+  another section.
+- Use repository-relative links and descriptive link text. Do not use `here`,
+  raw paths, or a document title that misrepresents the linked authority.
+- Prefer stable product and contract language over incidental code layout,
+  temporary issue state, or implementation chronology.
+
+## Related Documents
+
+- [Docs Agent Guide](AGENTS.md)
+- [Core Statements](core-statements.md)
+- [Glossary](glossary.md)
+- [Open Questions](open-questions.md)
+- [Testing and Validation Policy](testing.md)

--- a/docs/log-modules/AGENTS.md
+++ b/docs/log-modules/AGENTS.md
@@ -22,6 +22,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Keep Log Module design aligned with the canonical logging policy in `../core-statements.md` and `../security-model.md`.
 - Record unresolved destination backup, restore, migration, retention-bound, purge-execution, and remote-credential choices in `../open-questions.md`.
 - Make minimal, targeted changes and update this inventory when assets are added, removed, renamed, or moved.

--- a/docs/mfa-modules/AGENTS.md
+++ b/docs/mfa-modules/AGENTS.md
@@ -21,6 +21,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Keep MFA Module design aligned with `../security-model.md` and record settled commitments in `../core-statements.md`.
 - Use `../glossary.md` for canonical terminology and record unresolved MFA method or enrollment-lifecycle decisions in `../open-questions.md`.
 - Make minimal, targeted changes and update this inventory when assets are added, removed, renamed, or moved.

--- a/docs/plan/AGENTS.md
+++ b/docs/plan/AGENTS.md
@@ -27,6 +27,9 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read the nearest `AGENTS.md`, then `../AGENTS.md`, and the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the
+  [Documentation Standards](../documentation-standards.md) and apply its
+  authority, document-type, lifecycle, structure, and writing rules.
 - Read `issues/issues.md` before changing how open work is summarized or mapped to GitHub Project metadata.
 - Read the affected document in `milestones/` before changing its outcomes. Keep milestones aligned with canonical documents for settled product, security, and technical decisions; unresolved choices remain in [Open Questions](../open-questions.md).
 - Read `project/AGENTS.md` and `project/project-standards.md` before changing

--- a/docs/plan/issues/AGENTS.md
+++ b/docs/plan/issues/AGENTS.md
@@ -27,6 +27,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, `../../AGENTS.md`, and the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Read `templates/AGENTS.md` before changing an agent-created issue body template.
 - Create an issue by copying the matching template in `templates/` beginning with `##` into a temporary body file, replacing every bracketed placeholder, and passing it to `gh issue create --body-file`.
 - Set the native issue type with `gh issue create --type`; then assign the

--- a/docs/plan/issues/templates/AGENTS.md
+++ b/docs/plan/issues/templates/AGENTS.md
@@ -31,6 +31,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, `../../AGENTS.md`, `../../../AGENTS.md`, and `../../../../AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Select the template whose hidden `Native type` value matches the issue being created.
 - Copy only the sections beginning with `##` into the temporary body file passed to `gh issue create --body-file`.
 - Replace every bracketed placeholder before creating the issue.

--- a/docs/plan/milestones/AGENTS.md
+++ b/docs/plan/milestones/AGENTS.md
@@ -39,6 +39,7 @@ Follow this section for workflow, sequencing, and decision order when making cha
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, `../../AGENTS.md`,
   and the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Keep changes focused on the affected milestone. When a milestone is added,
   removed, moved, or renamed, update the applicable parent asset inventories in
   the same change.
@@ -59,15 +60,19 @@ Treat every rule in this section as mandatory for formatting, naming, scope boun
 - Reorganize, move, add, or remove documentation as needed when a change makes the current structure unclear, duplicates information, or places information outside its owning document.
 - Keep documentation focused and navigable. When a document grows broad, difficult to navigate, or mixes distinct concerns, split it into focused, appropriately named documents and organize them within `docs/`.
 - The preceding documentation-maintenance requirement must appear verbatim in every `AGENTS.md` in this repository.
+- Preserve the required heading order and keep this guide under 100 lines.
 - Name milestone documents `milestone-<number>.md` and title them
   `# Milestone <number>: <title>`.
 - Keep each milestone's `## Goals` section after its title and its
   `## Related Documents` section at the end of the file.
 - Keep goals as unchecked Markdown checklist items until their outcome is
   complete and verified.
-- Preserve a final `## Related Documents` section with non-numbered links to
-  existing repository-relative canonical documents; update it when referenced
-  documentation changes.
+- Any `AGENTS.md` created under `docs/` must keep Related Documents maintenance requirements integrated as bullets in `Standards and Conventions`.
+- Every production document must include a `## Related Documents` section at the end of the document.
+- `Related Documents` entries must use non-numbered Markdown link bullets in this format: `[Description](path)`.
+- Include only valid, repository-relative links to existing canonical documents.
+- Update `Related Documents` in the same change whenever files are added, moved, renamed, replaced, or retired.
+- Remove stale links and add canonical links so the section reflects current source-of-truth references.
 - Use the canonical names from `../../glossary.md` and format their first
   substantive use in a section as bold glossary links.
 - Link to canonical documents rather than restating settled product, security,

--- a/docs/plan/project/AGENTS.md
+++ b/docs/plan/project/AGENTS.md
@@ -28,6 +28,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, `../../AGENTS.md`, and the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Refresh type, label, GitHub Project field, milestone, and Project status
   values from GitHub before changing `project-standards.md`.
 - Preserve the exact configured name and capitalization of each GitHub value in

--- a/docs/server/AGENTS.md
+++ b/docs/server/AGENTS.md
@@ -30,6 +30,9 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing this directory, read this `AGENTS.md`, then `../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the
+  [Documentation Standards](../documentation-standards.md) and apply its
+  authority, document-type, lifecycle, structure, and writing rules.
 - Keep shared Server design documentation directly in this folder; place boundary-specific detail in its appropriate child directory.
 - Update `../core-statements.md` for settled commitments and `../open-questions.md` for unresolved choices instead of treating local design documentation as their replacement.
 - Make minimal, targeted changes and update this inventory when assets are added, removed, renamed, or moved.

--- a/docs/server/api/AGENTS.md
+++ b/docs/server/api/AGENTS.md
@@ -21,6 +21,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, then `../../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Add API contract detail only after the relevant wire-format or compatibility decision is settled; keep unresolved choices in `../../open-questions.md`.
 - Keep service-specific **[Operation](../../glossary.md#applications-and-interfaces)** inputs and effects in `../../service-modules/`, and use `../../glossary.md` for canonical terminology.
 - Make minimal, targeted changes and update this inventory when assets are added, removed, renamed, or moved.

--- a/docs/server/audit/AGENTS.md
+++ b/docs/server/audit/AGENTS.md
@@ -21,6 +21,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, then `../../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Keep audit design aligned with `../../core-statements.md` and `../../security-model.md`; record unresolved retention and backup choices in `../../open-questions.md`.
 - Keep operational diagnosis in `../observability/` and Audit Log storage and delivery design in `../../log-modules/`.
 - Make minimal, targeted changes and update this inventory when assets are added, removed, renamed, or moved.

--- a/docs/server/authentication/AGENTS.md
+++ b/docs/server/authentication/AGENTS.md
@@ -22,6 +22,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, then `../../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Keep authentication design aligned with `../../security-model.md` and record only settled commitments in `../../core-statements.md`.
 - Keep authorization evaluation in `../authorization/` and use `../../glossary.md` for canonical terminology.
 - Make minimal, targeted changes and update this inventory when assets are added, removed, renamed, or moved.

--- a/docs/server/authorization/AGENTS.md
+++ b/docs/server/authorization/AGENTS.md
@@ -23,6 +23,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, then `../../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Keep authorization design aligned with `../../security-model.md` and record only settled commitments in `../../core-statements.md`.
 - Keep credential validation in `../authentication/` and service-specific **[Operation](../../glossary.md#applications-and-interfaces)** behavior in `../../service-modules/`.
 - Make minimal, targeted changes and update this inventory when assets are added, removed, renamed, or moved.

--- a/docs/server/automation-identities/AGENTS.md
+++ b/docs/server/automation-identities/AGENTS.md
@@ -22,6 +22,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, then `../../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Keep Automation Identity design aligned with `../../security-model.md` and record only settled commitments in `../../core-statements.md`.
 - Keep general credential validation in `../authentication/`, authorization policy evaluation in `../authorization/`, and Audit Log design in `../audit/`.
 - Make minimal, targeted changes and update this inventory when assets are added, removed, renamed, or moved.

--- a/docs/server/database/AGENTS.md
+++ b/docs/server/database/AGENTS.md
@@ -31,6 +31,7 @@ Follow this section for workflow, sequencing, and decision order when making cha
 
 - Before editing, read the nearest `AGENTS.md`, then `../AGENTS.md`,
   `../../AGENTS.md`, and the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Keep shared backend-contract design in this folder and place database-specific
   implementation detail in the applicable child directory.
 - Update `../../core-statements.md` for settled commitments and

--- a/docs/server/database/sqlite/AGENTS.md
+++ b/docs/server/database/sqlite/AGENTS.md
@@ -30,6 +30,7 @@ Follow this section for workflow, sequencing, and decision order when making cha
 
 - Before editing, read the nearest `AGENTS.md`, then `../AGENTS.md`,
   `../../AGENTS.md`, `../../../AGENTS.md`, and the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Keep SQLite-specific driver, schema migration, transaction, connection-health,
   and error behavior in this folder.
 - Update shared backend-contract documentation in `../` and canonical decisions

--- a/docs/server/observability/AGENTS.md
+++ b/docs/server/observability/AGENTS.md
@@ -21,6 +21,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, then `../../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Keep System Log design aligned with the canonical logging policy. Do not add implementation artifacts or metrics, tracing, monitoring, or alerting claims until the relevant decision is recorded in a canonical document.
 - Keep audit accountability in `../audit/` and use `../../glossary.md` for canonical terminology.
 - Make minimal, targeted changes and update this inventory when assets are added, removed, renamed, or moved.

--- a/docs/service-modules/AGENTS.md
+++ b/docs/service-modules/AGENTS.md
@@ -22,6 +22,9 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing this directory, read this `AGENTS.md`, then `../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the
+  [Documentation Standards](../documentation-standards.md) and apply its
+  authority, document-type, lifecycle, structure, and writing rules.
 - Place documentation shared by Service Modules directly in this folder; place Zendesk-specific detail in `zendesk/`.
 - Use `../glossary.md` for canonical terminology and link to its owning category rather than restating canonical definitions.
 - Make minimal, targeted changes and update this inventory when assets are added, removed, renamed, or moved.

--- a/docs/service-modules/zendesk/AGENTS.md
+++ b/docs/service-modules/zendesk/AGENTS.md
@@ -21,6 +21,7 @@ Use this section as the source of truth for what assets belong in this directory
 Follow this section for workflow, sequencing, and decision order when making changes in this directory.
 
 - Before editing, read this `AGENTS.md`, then `../AGENTS.md`, then `../../AGENTS.md`, then the repository-root `AGENTS.md`.
+- Before creating or updating a production document, read the [Documentation Standards](../../documentation-standards.md) and apply its authority, document-type, lifecycle, structure, and writing rules.
 - Keep Zendesk-specific material directly in this folder; move shared Service Module material to the parent `../` directory.
 - Use `../../glossary.md` for canonical terminology and link to its owning category rather than restating canonical definitions.
 - Make minimal, targeted changes and update this inventory when assets are added, removed, renamed, or moved.


### PR DESCRIPTION
# Summary

Add a canonical standard for production documentation under `docs/` so product references, component designs, planning records, open questions, and architecture decisions follow consistent authority, lifecycle, structure, splitting, and writing rules.

Route every existing documentation boundary through the new standard before agents create or update production documentation.

## Release Notes

- `docs(repo): add documentation standards`

### Issue Closure

None

## Impact

No runtime compatibility, configuration, migration, security, or rollback impact. This changes the documented workflow for creating and maintaining production documentation under `docs/`.

## Verification

- `git diff --check origin/dev...HEAD`
- VS Code Markdown diagnostics for `docs/`: no errors
- Documentation audit: all 30 `AGENTS.md` guides remain within 100 lines and contain one valid Documentation Standards route in `Usage Guidance`
- Documentation audit: repository-relative documentation links resolve successfully

## Documentation

- [Documentation Standards](docs/documentation-standards.md)

## Checklist

- [x] This PR targets `dev`.
- [x] Applied the required label and GitHub Project fields.
- [x] Applied the relevant milestone, when one applies.
- [x] Confirmed the change is focused and the diff was reviewed.
- [x] Validated all relevant documentation and feature specifications are updated, when applicable.
- [x] Ran relevant checks, or explained why they could not be run.
